### PR TITLE
Bump Firebase remote configs library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@
 buildscript {
     ext.kotlin_version = '1.6.21'
     ext.gradle_version = '7.2.1'
-    ext.buildtools_version = '33.0.0-rc4'
+    ext.buildtools_version = '33.0.0'
     ext.corektx_version = '1.7.0'
     ext.compilesdk_version = 32
 

--- a/firely-lib/build.gradle
+++ b/firely-lib/build.gradle
@@ -46,7 +46,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-config:21.1.0'
+    implementation 'com.google.firebase:firebase-config:21.1.1'
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/firely-lib/build.gradle
+++ b/firely-lib/build.gradle
@@ -46,7 +46,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-config:21.1.1'
+    implementation 'com.google.firebase:firebase-config-ktx:21.1.1'
     implementation "androidx.core:core-ktx:$corektx_version"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"


### PR DESCRIPTION
Updated the Firebase Remote configs library version due to an issue reported on the version it was set:
https://github.com/firebase/firebase-android-sdk/issues/3757