### PR TITLE
Add way to dispose/remove the observer of real time configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     ext.buildtools_version = '33.0.0'
     ext.corektx_version = '1.10.1'
     ext.compilesdk_version = 33
-    ext.lib_version = '0.3.0'
+    ext.lib_version = '0.3.1'
 
     repositories {
         google()

--- a/firely-lib/src/main/java/com/busbud/android/firely/LiveVariable.kt
+++ b/firely-lib/src/main/java/com/busbud/android/firely/LiveVariable.kt
@@ -22,15 +22,10 @@ package com.busbud.android.firely
 
 import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.firebase.remoteconfig.ConfigUpdate
 import com.google.firebase.remoteconfig.ConfigUpdateListener
-import com.google.firebase.remoteconfig.ConfigUpdateListenerRegistration
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
 
@@ -55,7 +50,10 @@ class LiveVariable<T : Any>(
         else -> throw ClassCastException("Unsupported")
     }
 
-    fun observeRealTime(lifecycleOwner: LifecycleOwner, onError: (() -> Unit)? = null) {
+    fun observeRealTime(
+        lifecycleOwner: LifecycleOwner,
+        onError: (() -> Unit)? = null
+    ): LiveVariableDisposable {
         val listenerRegistration =
             internalFirely.addConfigUpdateListener(object : ConfigUpdateListener {
                 override fun onUpdate(configUpdate: ConfigUpdate) {
@@ -76,5 +74,11 @@ class LiveVariable<T : Any>(
                 super.onDestroy(owner)
             }
         })
+
+        return object : LiveVariableDisposable {
+            override fun dispose() {
+                listenerRegistration.remove()
+            }
+        }
     }
 }

--- a/firely-lib/src/main/java/com/busbud/android/firely/LiveVariableDisposable.kt
+++ b/firely-lib/src/main/java/com/busbud/android/firely/LiveVariableDisposable.kt
@@ -1,0 +1,5 @@
+package com.busbud.android.firely
+
+interface LiveVariableDisposable {
+    fun dispose()
+}


### PR DESCRIPTION
Although we can link a LifecycleOwner to the `observerRealTime` method, there are situations where we don't want to simply associate with a lifecycle owner but also have the flexibility to dispose/remove the config update listener at a specific time. This Pull Requests aims to provide that flexibility.

This PR includes:
- Provide a disposable that can be used to remove the observer by the caller; 
- Bump version code;