### PR TITLE
Feature/add support for custom firebase instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  android: circleci/android@2.1.2
+  android: circleci/android@2.5.0
 
 #######################
 # Commands section
@@ -48,7 +48,7 @@ references:
   android_config: &android_config
     working_directory: ~/workspace
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2023.09
 
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -21,32 +21,23 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.8.21'
-    ext.gradle_version = '7.2.2'
-    ext.buildtools_version = '33.0.0'
-    ext.corektx_version = '1.10.1'
-    ext.compilesdk_version = 33
-    ext.lib_version = '0.3.1'
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:$gradle_version"
-        classpath 'com.google.gms:google-services:4.3.15'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-    }
+    ext.kotlin_version = '2.3.0'
+    ext.gradle_version = '8.10.1'
+    ext.buildtools_version = '35.0.0'
+    ext.corektx_version = '1.17.0'
+    ext.compilesdk_version = 36
+    ext.lib_version = '0.4.0'
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '8.10.1' apply false
+    id 'com.android.library' version '8.10.1' apply false
+    id 'com.google.gms.google-services' version '4.4.4' apply false
+    id 'org.jetbrains.kotlin.android' version '2.3.0' apply false
+    id 'org.jetbrains.kotlin.jvm' version '2.3.0' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.3.0' apply false
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/firely-lib/build.gradle
+++ b/firely-lib/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
 android {
+    namespace 'com.busbud.android.firely'
     compileSdk compilesdk_version
-    buildToolsVersion = buildtools_version
 
     defaultConfig {
         minSdkVersion 16
@@ -40,8 +40,8 @@ android {
         }
     }
     compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_17
     }
 
     publishing {
@@ -51,17 +51,21 @@ android {
     }
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
-    implementation 'com.google.firebase:firebase-config-ktx:21.4.0'
+    implementation 'com.google.firebase:firebase-config-ktx:22.1.2'
     implementation "androidx.core:core-ktx:$corektx_version"
-    implementation "androidx.preference:preference-ktx:1.2.0"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
+    implementation "androidx.preference:preference-ktx:1.2.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.10.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
-task sourceJar(type: Jar) {
+tasks.register('sourceJar', Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier "source"
+    archiveClassifier = "source"
 }
 
 publishing {

--- a/firely-lib/src/main/java/com/busbud/android/firely/Firely.kt
+++ b/firely-lib/src/main/java/com/busbud/android/firely/Firely.kt
@@ -21,6 +21,7 @@
 package com.busbud.android.firely
 
 import android.content.Context
+import com.google.firebase.FirebaseOptions
 import kotlin.reflect.KClass
 
 object Firely {
@@ -28,7 +29,7 @@ object Firely {
     private var logLevel = LogLevel.NONE
     private lateinit var internal: InternalFirely
 
-    fun setup(context: Context) : Firely {
+    fun setup(context: Context, secondaryFirebaseAppOptions: FirebaseOptions? = null): Firely {
         // Find the auto-generated FirelyConfig
         val firelyConfig = try {
             Class.forName("com.busbud.android.firely.FirelyConfig").newInstance() as IFirelyConfig
@@ -38,9 +39,9 @@ object Firely {
 
         // Start remote config
         try {
-            internal = InternalFirely(context, firelyConfig)
+            internal = InternalFirely(context, firelyConfig, secondaryFirebaseAppOptions)
         } catch (e: Exception) {
-            throw  IllegalArgumentException("Unable to instantiate FirebaseRemoteConfig", e)
+            throw IllegalArgumentException("Unable to instantiate FirebaseRemoteConfig", e)
         }
 
         return this
@@ -103,7 +104,7 @@ object Firely {
     private fun <T : Any> variable(name: IFirelyItem, clazz: KClass<T>): LiveVariable<T> {
         checkSetupCalled()
         if (name.key.isEmpty()) {
-            throw  IllegalArgumentException("Empty variable")
+            throw IllegalArgumentException("Empty variable")
         }
         return LiveVariable(name.key, internal, clazz)
     }

--- a/firely-plugin/build.gradle
+++ b/firely-plugin/build.gradle
@@ -19,39 +19,35 @@
  */
 
 plugins {
-    id 'kotlin'
+    id 'org.jetbrains.kotlin.jvm'
     id 'maven-publish'
-    id 'kotlinx-serialization'
-    id "com.gradle.plugin-publish" version "1.0.0"
+    id 'org.jetbrains.kotlin.plugin.serialization'
+    id 'com.gradle.plugin-publish' version '1.3.0'
 }
 
 dependencies {
-    repositories {
-        mavenCentral()
-    }
-
     implementation gradleApi()
-    implementation "com.android.tools.build:gradle:$gradle_version"
     implementation 'com.squareup:kotlinpoet:1.11.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0'
 }
 
-tasks.withType(JavaCompile) {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType(GroovyCompile) {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+tasks.withType(GroovyCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
+tasks.register('sourcesJar', Jar) {
+    dependsOn classes
     archiveClassifier.set("sources")
     from sourceSets.main.allSource
 }
 
-tasks.withType(Copy).all { duplicatesStrategy 'exclude' }
+tasks.withType(Copy).configureEach { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 
 artifacts {
     archives sourcesJar
@@ -60,20 +56,17 @@ artifacts {
 version = "$lib_version"
 group = "com.busbud"
 
-pluginBundle {
-    website = 'https://github.com/busbud/firely'
-    vcsUrl = 'https://github.com/busbud/firely'
-    description = "Library to simplify the integration and management of A/B testing"
-    tags = ['firely', 'remote_configs', 'firebase']
-}
-
 
 gradlePlugin {
+    website = 'https://github.com/busbud/firely'
+    vcsUrl = 'https://github.com/busbud/firely'
     plugins {
         firelyPlugin {
             id = 'com.busbud.android.firely'
             implementationClass = 'com.busbud.android.firely.FirelyPlugin'
             displayName = "Firely Plugin"
+            description = "Library to simplify the integration and management of A/B testing"
+            tags = ['firely', 'remote_configs', 'firebase']
         }
     }
 }

--- a/firely-sample/build.gradle
+++ b/firely-sample/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
     testImplementation 'junit:junit:4.13.2'
+    implementation 'com.google.firebase:firebase-config-ktx:22.1.2'
 
     implementation project(':firely-lib')
     implementation "androidx.core:core-ktx:$corektx_version"

--- a/firely-sample/build.gradle
+++ b/firely-sample/build.gradle
@@ -17,31 +17,21 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
  * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-//        mavenLocal()
-    }
-//    dependencies {
-//        classpath group: 'com.busbud.android', name: 'firely-plugin', version: "$lib_version"
-//    }
-}
-
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.google.gms.google-services'
-    id "com.busbud.android.firely" version "0.2.1"
+    id "com.busbud.android.firely" version "0.3.1"
 }
 
 android {
+    namespace 'com.busbud.android.firely.sample'
     compileSdk compilesdk_version
     buildToolsVersion = buildtools_version
 
     defaultConfig {
         applicationId "com.busbud.android.firely.sample"
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion compilesdk_version
         versionCode 1
         versionName "1.0"
@@ -53,6 +43,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_17
+    }
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {
@@ -60,8 +61,8 @@ dependencies {
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
     testImplementation 'junit:junit:4.13.2'
 
     implementation project(':firely-lib')

--- a/firely-sample/src/main/java/com/busbud/android/firely/sample/MainApplication.kt
+++ b/firely-sample/src/main/java/com/busbud/android/firely/sample/MainApplication.kt
@@ -22,11 +22,28 @@ package com.busbud.android.firely.sample
 
 import android.app.Application
 import com.busbud.android.firely.Firely
+import com.google.firebase.FirebaseOptions
 
 class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        simpleSetup()
+//        differentFirebaseProjectSetup()
+    }
+
+    private fun simpleSetup() {
         Firely.setup(this).setDebugMode(BuildConfig.DEBUG)
+    }
+
+    private fun differentFirebaseProjectSetup() {
+        val firebaseOptions = FirebaseOptions.Builder()
+            .setProjectId("[SET-YOUR-PROJECT-ID-HERE]")
+            .setApplicationId("[SET-YOUR-APP-ID-HERE]")
+            .setApiKey("[SET-YOUR-API-KEY-HERE]")
+            .build()
+
+        Firely.setup(this, secondaryFirebaseAppOptions = firebaseOptions)
+            .setDebugMode(BuildConfig.DEBUG)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,6 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
-android.disableAutomaticComponentCreation=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
+#Wed Dec 31 11:15:54 WET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,4 +18,20 @@
  * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':firely-sample', ':firely-lib', ':firely-plugin'


### PR DESCRIPTION
## Motivation
We want to have the ability to use a specific Firebase project for Remote Configs, while having a different Firebase project as  default.

## What was done
- Updated the gradle configuration to be more up to date(still not moved dependencies to .toml format though)
- Implemented logic to allow passing a `secondaryFirebaseOptions` that will be used to create the secondary Firebase app that will serve the remote configs

## Testing Notes
On firely-sample you should be able to adjust the logic on the `differentFirebaseProjectSetup` to use a different project and test it accordingly.