### PR TITLE
Fix inconsistent JVM-target compatibility issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     ext.buildtools_version = '35.0.0'
     ext.corektx_version = '1.17.0'
     ext.compilesdk_version = 36
-    ext.lib_version = '0.4.0'
+    ext.lib_version = '0.4.1'
 }
 
 plugins {

--- a/firely-lib/build.gradle
+++ b/firely-lib/build.gradle
@@ -68,14 +68,16 @@ tasks.register('sourceJar', Jar) {
     archiveClassifier = "source"
 }
 
-publishing {
-    publications {
-        firely(MavenPublication) {
-            groupId 'com.busbud.android'
-            artifactId 'firely'
-            version "$lib_version"
-            artifact(sourceJar)
-            artifact("$buildDir/outputs/aar/firely-lib-release.aar")
+afterEvaluate {
+    publishing {
+        publications {
+            firely(MavenPublication) {
+                groupId 'com.busbud.android'
+                artifactId 'firely'
+                version "$lib_version"
+                artifact(sourceJar)
+                artifact(bundleReleaseAar)
+            }
         }
     }
 }

--- a/firely-lib/build.gradle
+++ b/firely-lib/build.gradle
@@ -68,15 +68,15 @@ tasks.register('sourceJar', Jar) {
     archiveClassifier = "source"
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            firely(MavenPublication) {
-                groupId 'com.busbud.android'
-                artifactId 'firely'
-                version "$lib_version"
-                artifact(sourceJar)
-                artifact(bundleReleaseAar)
+publishing {
+    publications {
+        firely(MavenPublication) {
+            groupId 'com.busbud.android'
+            artifactId 'firely'
+            version "$lib_version"
+
+            afterEvaluate {
+                from components.release
             }
         }
     }

--- a/firely-plugin/build.gradle
+++ b/firely-plugin/build.gradle
@@ -46,17 +46,11 @@ kotlin {
     jvmToolchain(17)
 }
 
-tasks.register('sourcesJar', Jar) {
-    dependsOn classes
-    archiveClassifier.set("sources")
-    from sourceSets.main.allSource
+java {
+    withSourcesJar()
 }
 
 tasks.withType(Copy).configureEach { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
-
-artifacts {
-    archives sourcesJar
-}
 
 version = "$lib_version"
 group = "com.busbud"

--- a/firely-plugin/build.gradle
+++ b/firely-plugin/build.gradle
@@ -29,16 +29,21 @@ dependencies {
     implementation gradleApi()
     implementation 'com.squareup:kotlinpoet:1.11.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0'
+    implementation 'com.android.tools.build:gradle:8.10.1'
 }
 
 tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType(GroovyCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    jvmToolchain(17)
 }
 
 tasks.register('sourcesJar', Jar) {
@@ -79,7 +84,6 @@ publishing {
             version "$lib_version"
 
             from components.java
-            artifact sourcesJar
         }
     }
 }

--- a/firely-plugin/build.gradle
+++ b/firely-plugin/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation gradleApi()
     implementation 'com.squareup:kotlinpoet:1.11.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0'
-    implementation 'com.android.tools.build:gradle:8.10.1'
+    compileOnly 'com.android.tools.build:gradle:8.10.1'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17


### PR DESCRIPTION
## Fix JitPack Build - JVM Target Compatibility

### Problem
JitPack build was failing with inconsistent JVM-target compatibility error:
`Inconsistent JVM-target compatibility detected for tasks 'compileJava' 1.8 and 'compileKotlin' 17` ( see [here](https://jitpack.io/com/github/busbud/firely/0.4.0/build.log))

### Changes

| File | Change |
|------|--------|
| `jitpack.yml` | Updated JDK from `openjdk11` to `openjdk17` |
| `firely-plugin/build.gradle` | Updated JVM target from 1.8 → 17; added missing AGP dependency; fixed duplicate sources artifact |
| `firely-lib/build.gradle` | Fixed AAR artifact reference to use `bundleReleaseAar` task instead of file path |

Also updated version to 0.4.1.